### PR TITLE
[FEAT] 메시지 API 구현

### DIFF
--- a/src/main/java/com/cone/cone/domain/messages/code/MessageSuccessCode.java
+++ b/src/main/java/com/cone/cone/domain/messages/code/MessageSuccessCode.java
@@ -1,0 +1,26 @@
+package com.cone.cone.domain.messages.code;
+
+import com.cone.cone.global.code.SuccessCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum MessageSuccessCode implements SuccessCode {
+    SUCCESS_GET_MESSAGES(HttpStatus.OK, "메시지 목록 조회에 성공하셨습니다");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return this.status;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/cone/cone/domain/messages/entity/Message.java
+++ b/src/main/java/com/cone/cone/domain/messages/entity/Message.java
@@ -4,11 +4,13 @@ import com.cone.cone.domain.room.entity.Room;
 import com.cone.cone.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
 @Table(name = "messages")
+@NoArgsConstructor
 public class Message {
     @Id
     @GeneratedValue(strategy = IDENTITY)

--- a/src/main/java/com/cone/cone/domain/messages/entity/Message.java
+++ b/src/main/java/com/cone/cone/domain/messages/entity/Message.java
@@ -3,6 +3,7 @@ package com.cone.cone.domain.messages.entity;
 import com.cone.cone.domain.room.entity.Room;
 import com.cone.cone.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.Builder;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -23,4 +24,11 @@ public class Message {
 
     @Column(nullable = false, updatable = false)
     private String content;
+
+    @Builder
+    private Message(Room room, User sender, String content) {
+        this.room = room;
+        this.sender = sender;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/cone/cone/domain/messages/repository/MessageRepository.java
+++ b/src/main/java/com/cone/cone/domain/messages/repository/MessageRepository.java
@@ -1,0 +1,13 @@
+package com.cone.cone.domain.messages.repository;
+
+import com.cone.cone.domain.messages.entity.Message;
+import com.cone.cone.domain.room.entity.Room;
+import com.cone.cone.domain.user.entity.Mentee;
+import com.cone.cone.domain.user.entity.Mentor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+    List<Message> findAllByRoom (Room room);
+}

--- a/src/main/java/com/cone/cone/domain/messages/service/MessageService.java
+++ b/src/main/java/com/cone/cone/domain/messages/service/MessageService.java
@@ -1,0 +1,10 @@
+package com.cone.cone.domain.messages.service;
+
+import com.cone.cone.domain.messages.entity.Message;
+
+import java.util.List;
+
+public interface MessageService {
+    Message createMessage(Long id);
+    List<Message> getMessagesByRoomId(Long roomId);
+}

--- a/src/main/java/com/cone/cone/domain/messages/service/MessageService.java
+++ b/src/main/java/com/cone/cone/domain/messages/service/MessageService.java
@@ -5,6 +5,6 @@ import com.cone.cone.domain.messages.entity.Message;
 import java.util.List;
 
 public interface MessageService {
-    Message createMessage(Long id);
+    Message createMessage(Long roomId, Long senderId, String content);
     List<Message> getMessagesByRoomId(Long roomId);
 }

--- a/src/main/java/com/cone/cone/domain/messages/service/MessageServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/messages/service/MessageServiceImpl.java
@@ -1,0 +1,56 @@
+package com.cone.cone.domain.messages.service;
+
+import com.cone.cone.domain.messages.entity.Message;
+import com.cone.cone.domain.messages.repository.MessageRepository;
+import com.cone.cone.domain.room.dto.RoomCreateRequest;
+import com.cone.cone.domain.room.entity.Room;
+import com.cone.cone.domain.room.repository.RoomRepository;
+import com.cone.cone.domain.room.service.RoomService;
+import com.cone.cone.domain.user.entity.Mentee;
+import com.cone.cone.domain.user.entity.Mentor;
+import com.cone.cone.domain.user.entity.User;
+import com.cone.cone.domain.user.repository.MenteeRepository;
+import com.cone.cone.domain.user.repository.MentorRepository;
+import com.cone.cone.domain.user.repository.UserRepository;
+import com.cone.cone.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.cone.cone.domain.room.code.RoomExceptionCode.ALREADY_EXIST_ROOM;
+import static com.cone.cone.domain.room.code.RoomExceptionCode.NOT_FOUND_ROOM;
+import static com.cone.cone.domain.user.code.MenteeExceptionCode.NOT_FOUND_MENTEE;
+import static com.cone.cone.domain.user.code.MentorExceptionCode.NOT_FOUND_MENTOR;
+import static com.cone.cone.domain.user.code.UserExceptionCode.NOT_FOUND_USER;
+
+@Service
+@RequiredArgsConstructor
+public class MessageServiceImpl implements MessageService {
+    private final RoomRepository roomRepository;
+    private final UserRepository userRepository;
+    private final MessageRepository messageRepository;
+
+    public Message createMessage(Long roomId, Long senderId, String content) {
+        final Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_ROOM));
+
+        final User sender = userRepository.findById(senderId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_USER));
+
+        final Message newMessage = Message.builder()
+                .room(room)
+                .sender(sender)
+                .content(content)
+                .build();
+
+        return messageRepository.save(newMessage);
+    }
+
+    public List<Message> getMessagesByRoomId(Long roomId) {
+        final Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_ROOM));
+
+        return messageRepository.findAllByRoom(room);
+    }
+}

--- a/src/main/java/com/cone/cone/domain/room/code/RoomExceptionCode.java
+++ b/src/main/java/com/cone/cone/domain/room/code/RoomExceptionCode.java
@@ -10,7 +10,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum RoomExceptionCode implements ExceptionCode {
     // 400 Bad Request
-    ALREADY_EXIST_ROOM(HttpStatus.BAD_REQUEST, "이미 존재하는 멘토링 방입니다");
+    ALREADY_EXIST_ROOM(HttpStatus.BAD_REQUEST, "이미 존재하는 멘토링 방입니다"),
+
+    // 404 Not Found
+    NOT_FOUND_ROOM(HttpStatus.NOT_FOUND, "요청하신 멘토링 방을 찾을 수 없습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/cone/cone/domain/room/controller/RoomApi.java
+++ b/src/main/java/com/cone/cone/domain/room/controller/RoomApi.java
@@ -1,10 +1,14 @@
 package com.cone.cone.domain.room.controller;
 
+import com.cone.cone.domain.messages.entity.Message;
 import com.cone.cone.domain.room.dto.RoomCreateRequest;
 import com.cone.cone.domain.room.entity.Room;
 import com.cone.cone.global.response.ResponseTemplate;
 import org.springframework.http.ResponseEntity;
 
+import java.util.List;
+
 public interface RoomApi {
     ResponseEntity<ResponseTemplate<Room>> createRoom(RoomCreateRequest request);
+    ResponseEntity<ResponseTemplate<List<Message>>> getMessagesById(Long id);
 }

--- a/src/main/java/com/cone/cone/domain/room/controller/RoomController.java
+++ b/src/main/java/com/cone/cone/domain/room/controller/RoomController.java
@@ -1,5 +1,8 @@
 package com.cone.cone.domain.room.controller;
 
+import com.cone.cone.domain.messages.entity.Message;
+import com.cone.cone.domain.messages.service.MessageService;
+import com.cone.cone.domain.messages.service.MessageServiceImpl;
 import com.cone.cone.domain.room.dto.RoomCreateRequest;
 import com.cone.cone.domain.room.entity.Room;
 import com.cone.cone.domain.room.service.RoomService;
@@ -13,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 import java.util.List;
 
+import static com.cone.cone.domain.messages.code.MessageSuccessCode.SUCCESS_GET_MESSAGES;
 import static com.cone.cone.domain.room.code.RoomSuccessCode.SUCCESS_CREATE_ROOM;
 import static com.cone.cone.domain.room.code.RoomSuccessCode.SUCCESS_GET_ROOMS;
 
@@ -21,10 +25,17 @@ import static com.cone.cone.domain.room.code.RoomSuccessCode.SUCCESS_GET_ROOMS;
 @RequiredArgsConstructor
 public class RoomController implements RoomApi {
     private final RoomService roomService;
+    private final MessageService messageService;
 
     @PostMapping
     public ResponseEntity<ResponseTemplate<Room>> createRoom(@RequestBody @Valid RoomCreateRequest request) {
         final Room room = roomService.createRoom(request);
         return ResponseEntity.created(URI.create("/rooms" + room.getId())).body(ResponseTemplate.success(SUCCESS_CREATE_ROOM, room));
+    }
+
+    @GetMapping("/{id}/messages")
+    public ResponseEntity<ResponseTemplate<List<Message>>> getMessagesById(@PathVariable Long id) {
+        final List<Message> messages = messageService.getMessagesByRoomId(id);
+        return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_GET_MESSAGES, messages));
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/code/UserExceptionCode.java
+++ b/src/main/java/com/cone/cone/domain/user/code/UserExceptionCode.java
@@ -1,0 +1,26 @@
+package com.cone.cone.domain.user.code;
+
+import com.cone.cone.global.code.ExceptionCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum UserExceptionCode implements ExceptionCode {
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "요청하신 사용자를 찾을 수 없습니다");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return this.status;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}


### PR DESCRIPTION
## 📒 작업한 내용
- 채팅방 메시지 목록 조회 api 구현
- 메시지 생성 서비스 메서드 구현

## 💭 PR POINT
- 

## 📷 스크린샷
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 채팅방 메시지 목록 조회| <img src = "https://github.com/user-attachments/assets/a8f99cd0-9d9a-4e55-b614-85132357def5" width ="500">|

## 🌈 관련 이슈
- Resolved: #8 
