### PR TITLE
[FEAT] 멘토 프로필 조회 API 구현

### DIFF
--- a/src/main/java/com/cone/cone/domain/auth/controller/AuthApi.java
+++ b/src/main/java/com/cone/cone/domain/auth/controller/AuthApi.java
@@ -2,11 +2,16 @@ package com.cone.cone.domain.auth.controller;
 
 import com.cone.cone.domain.user.dto.request.*;
 import com.cone.cone.domain.user.dto.response.*;
+import com.cone.cone.global.annotation.*;
 import com.cone.cone.global.response.*;
 import jakarta.servlet.http.*;
 import jakarta.validation.*;
 import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
 
 public interface AuthApi {
     ResponseEntity<ResponseTemplate<RoleResponse>> login(HttpServletRequest httpServletRequest, @Valid LoginRequest request);
+
+    ResponseEntity<ResponseTemplate<RoleResponse>> onboarding(HttpServletRequest httpServletRequest, Long userId,
+                                                              @Valid RoleRequest request);
 }

--- a/src/main/java/com/cone/cone/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/auth/service/AuthServiceImpl.java
@@ -32,6 +32,8 @@ public class AuthServiceImpl implements AuthService {
                     .role(Role.GUEST)
                     .platformType(request.platformType())
                     .platformId(userInfo.id())
+                    .username(userInfo.nickname())
+                    .profileImgUrl(userInfo.profileUrl())
                     .build();
             userRepository.save(newUser);
             sessionService.createSession(httpServletRequest, newUser.getId(), newUser.getRole());

--- a/src/main/java/com/cone/cone/domain/user/code/MentorSuccessCode.java
+++ b/src/main/java/com/cone/cone/domain/user/code/MentorSuccessCode.java
@@ -1,0 +1,24 @@
+package com.cone.cone.domain.user.code;
+
+import com.cone.cone.global.code.*;
+import lombok.*;
+import org.springframework.http.*;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum MentorSuccessCode implements SuccessCode {
+    SUCCESS_GET_MENTOR_PROFILE(HttpStatus.OK, "멘토 프로필 조회에 성공했습니다");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return this.status;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/cone/cone/domain/user/controller/MenteeController.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MenteeController.java
@@ -19,7 +19,7 @@ import static com.cone.cone.domain.room.code.RoomSuccessCode.SUCCESS_GET_ROOMS;
 @RestController
 @RequestMapping("/mentees")
 @RequiredArgsConstructor
-public class MenteeController {
+public class MenteeController implements MenteeApi {
     private final RoomService roomService;
 
     @GetMapping("/{id}/rooms")

--- a/src/main/java/com/cone/cone/domain/user/controller/MentorApi.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MentorApi.java
@@ -1,6 +1,7 @@
 package com.cone.cone.domain.user.controller;
 
 import com.cone.cone.domain.room.entity.Room;
+import com.cone.cone.domain.user.dto.response.*;
 import com.cone.cone.global.response.ResponseTemplate;
 import org.springframework.http.ResponseEntity;
 
@@ -8,4 +9,6 @@ import java.util.List;
 
 public interface MentorApi {
     ResponseEntity<ResponseTemplate<List<Room>>> getRoomsById(Long id);
+
+    ResponseEntity<ResponseTemplate<MentorProfileResponse>> getMentorProfile(Long mentorId);
 }

--- a/src/main/java/com/cone/cone/domain/user/controller/MentorController.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MentorController.java
@@ -2,7 +2,9 @@ package com.cone.cone.domain.user.controller;
 
 import com.cone.cone.domain.room.entity.Room;
 import com.cone.cone.domain.room.service.RoomService;
+import com.cone.cone.domain.user.dto.response.*;
 import com.cone.cone.global.response.ResponseTemplate;
+import jakarta.validation.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,12 +19,17 @@ import static com.cone.cone.domain.room.code.RoomSuccessCode.SUCCESS_GET_ROOMS;
 @RestController
 @RequestMapping("/mentors")
 @RequiredArgsConstructor
-public class MentorController {
+public class MentorController implements MentorApi{
     private final RoomService roomService;
 
     @GetMapping("/{id}/rooms")
     public ResponseEntity<ResponseTemplate<List<Room>>> getRoomsById(@PathVariable Long id) {
         final List<Room> rooms = roomService.getRoomsByMentorId(id);
         return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_GET_ROOMS, rooms));
+    }
+
+    @GetMapping("/{mentorId}")
+    public ResponseEntity<ResponseTemplate<MentorProfileResponse>> getMentorProfile(@Valid @PathVariable("mentorId") Long mentorId) {
+        return null;
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/controller/MentorController.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MentorController.java
@@ -3,9 +3,10 @@ package com.cone.cone.domain.user.controller;
 import com.cone.cone.domain.room.entity.Room;
 import com.cone.cone.domain.room.service.RoomService;
 import com.cone.cone.domain.user.dto.response.*;
+import com.cone.cone.domain.user.service.*;
 import com.cone.cone.global.response.ResponseTemplate;
 import jakarta.validation.*;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,12 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 import static com.cone.cone.domain.room.code.RoomSuccessCode.SUCCESS_GET_ROOMS;
+import static com.cone.cone.domain.user.code.MentorSuccessCode.SUCCESS_GET_MENTOR_PROFILE;
 
 @RestController
 @RequestMapping("/mentors")
 @RequiredArgsConstructor
 public class MentorController implements MentorApi{
     private final RoomService roomService;
+    private final MentorService mentorService;
 
     @GetMapping("/{id}/rooms")
     public ResponseEntity<ResponseTemplate<List<Room>>> getRoomsById(@PathVariable Long id) {
@@ -30,6 +33,7 @@ public class MentorController implements MentorApi{
 
     @GetMapping("/{mentorId}")
     public ResponseEntity<ResponseTemplate<MentorProfileResponse>> getMentorProfile(@Valid @PathVariable("mentorId") Long mentorId) {
-        return null;
+        val response = mentorService.getMentorProfile(mentorId);
+        return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_GET_MENTOR_PROFILE, response));
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/dto/response/MentorProfileResponse.java
+++ b/src/main/java/com/cone/cone/domain/user/dto/response/MentorProfileResponse.java
@@ -1,0 +1,14 @@
+package com.cone.cone.domain.user.dto.response;
+
+import com.cone.cone.domain.user.entity.*;
+
+public record MentorProfileResponse(
+        long mentorId,
+        AuditStatus auditStatus,
+        String profileUrl,
+        String name,
+        String keyword,
+        String resume,
+        String introduction
+) {
+}

--- a/src/main/java/com/cone/cone/domain/user/dto/response/MentorProfileResponse.java
+++ b/src/main/java/com/cone/cone/domain/user/dto/response/MentorProfileResponse.java
@@ -5,10 +5,14 @@ import com.cone.cone.domain.user.entity.*;
 public record MentorProfileResponse(
         long mentorId,
         AuditStatus auditStatus,
-        String profileUrl,
+        String profileImgUrl,
         String name,
         String keyword,
         String resume,
         String introduction
 ) {
+    public static MentorProfileResponse from(Mentor mentor) {
+        return new MentorProfileResponse(mentor.getId(), mentor.getAuditStatus(), mentor.getProfileImgUrl(),
+                mentor.getUsername(), mentor.getKeyword(), mentor.getResume(), mentor.getIntroduction());
+    }
 }

--- a/src/main/java/com/cone/cone/domain/user/entity/Mentee.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/Mentee.java
@@ -8,7 +8,7 @@ public class Mentee {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/cone/cone/domain/user/entity/Mentor.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/Mentor.java
@@ -1,9 +1,11 @@
 package com.cone.cone.domain.user.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Table(name = "mentors")
+@Getter
 public class Mentor {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -25,6 +27,13 @@ public class Mentor {
     private AuditStatus auditStatus;
     private String rejectReason;
 
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    public String getProfileImgUrl() {
+        return user.getProfileImgUrl();
+    }
 
 
 }

--- a/src/main/java/com/cone/cone/domain/user/entity/Mentor.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/Mentor.java
@@ -13,6 +13,9 @@ public class Mentor {
     private User user;
 
     @Column(nullable = false)
+    private String keyword;
+
+    @Column(nullable = false)
     private String resume;
 
     @Column(nullable = false)

--- a/src/main/java/com/cone/cone/domain/user/entity/Mentor.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/Mentor.java
@@ -10,7 +10,7 @@ public class Mentor {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/cone/cone/domain/user/entity/User.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/User.java
@@ -16,6 +16,8 @@ public class User {
     @Column(nullable = false) @Enumerated(value = EnumType.STRING)
     private PlatformType platformType;
     private String platformId;
+    private String username;
+    private String profileImgUrl;
 
     @Builder
     private User(Role role, PlatformType platformType, String platformId) {

--- a/src/main/java/com/cone/cone/domain/user/entity/User.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/User.java
@@ -16,7 +16,6 @@ public class User {
     @Column(nullable = false) @Enumerated(value = EnumType.STRING)
     private PlatformType platformType;
     private String platformId;
-    private Long openId;
 
     @Builder
     private User(Role role, PlatformType platformType, String platformId) {

--- a/src/main/java/com/cone/cone/domain/user/entity/User.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/User.java
@@ -20,10 +20,12 @@ public class User {
     private String profileImgUrl;
 
     @Builder
-    private User(Role role, PlatformType platformType, String platformId) {
+    private User(Role role, PlatformType platformType, String platformId, String username, String profileImgUrl) {
         this.role = role;
         this.platformType = platformType;
         this.platformId = platformId;
+        this.username = username;
+        this.profileImgUrl = profileImgUrl;
     }
 
     public void changeRole(final Role role) {

--- a/src/main/java/com/cone/cone/domain/user/repository/MentorRepository.java
+++ b/src/main/java/com/cone/cone/domain/user/repository/MentorRepository.java
@@ -1,10 +1,17 @@
 package com.cone.cone.domain.user.repository;
 
+import static com.cone.cone.domain.user.code.MentorExceptionCode.NOT_FOUND_MENTOR;
+import static com.cone.cone.global.code.CommonExceptionCode.AUTHENTICATION_REQUIRED;
+
 import com.cone.cone.domain.user.entity.Mentor;
 import com.cone.cone.domain.user.entity.User;
+import com.cone.cone.global.exception.*;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
+    default Mentor findByIdOrThrow(final Long mentorId) {
+        return findById(mentorId).orElseThrow(() -> new CustomException(NOT_FOUND_MENTOR));
+    }
 }

--- a/src/main/java/com/cone/cone/domain/user/service/MentorService.java
+++ b/src/main/java/com/cone/cone/domain/user/service/MentorService.java
@@ -1,0 +1,7 @@
+package com.cone.cone.domain.user.service;
+
+import com.cone.cone.domain.user.dto.response.*;
+
+public interface MentorService {
+    MentorProfileResponse getMentorProfile(Long mentorId);
+}

--- a/src/main/java/com/cone/cone/domain/user/service/MentorServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/user/service/MentorServiceImpl.java
@@ -1,6 +1,8 @@
 package com.cone.cone.domain.user.service;
 
 import com.cone.cone.domain.user.dto.response.*;
+import com.cone.cone.domain.user.entity.*;
+import com.cone.cone.domain.user.repository.*;
 import lombok.*;
 import org.springframework.stereotype.*;
 import org.springframework.transaction.annotation.*;
@@ -9,8 +11,10 @@ import org.springframework.transaction.annotation.*;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MentorServiceImpl implements MentorService{
+    private final MentorRepository mentorRepository;
 
     public MentorProfileResponse getMentorProfile(final Long mentorId) {
-        return null;
+        Mentor mentor = mentorRepository.findByIdOrThrow(mentorId);
+        return MentorProfileResponse.from(mentor);
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/service/MentorServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/user/service/MentorServiceImpl.java
@@ -1,0 +1,16 @@
+package com.cone.cone.domain.user.service;
+
+import com.cone.cone.domain.user.dto.response.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MentorServiceImpl implements MentorService{
+
+    public MentorProfileResponse getMentorProfile(final Long mentorId) {
+        return null;
+    }
+}


### PR DESCRIPTION
## 📒 작업한 내용
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 멘토 프로필 조회 API 구현
- 소셜 로그인 로직에서 사용자 이름과 프로필 이미지를 가져오도록 로직 반영

## 💭 PR POINT
<!-- 덧붙이고 싶은 내용이 있다면! -->
- X

## 📷 스크린샷
<!-- API 요청 결과를 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 멘토 프로필 조회 | <img src = "https://github.com/user-attachments/assets/f8a2cb45-dcae-453f-b307-bdd4956839af" width ="500">|


## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #16
