### PR TITLE
[FEAT] 멘티 프로필 조회 API 구현

### DIFF
--- a/src/main/java/com/cone/cone/domain/user/code/MenteeSuccessCode.java
+++ b/src/main/java/com/cone/cone/domain/user/code/MenteeSuccessCode.java
@@ -1,0 +1,24 @@
+package com.cone.cone.domain.user.code;
+
+import com.cone.cone.global.code.*;
+import lombok.*;
+import org.springframework.http.*;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum MenteeSuccessCode implements SuccessCode {
+    SUCCESS_GET_MENTEE_PROFILE(HttpStatus.OK, "멘티 프로필 조회에 성공했습니다");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return this.status;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/cone/cone/domain/user/controller/MenteeApi.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MenteeApi.java
@@ -1,6 +1,7 @@
 package com.cone.cone.domain.user.controller;
 
 import com.cone.cone.domain.room.entity.Room;
+import com.cone.cone.domain.user.dto.response.*;
 import com.cone.cone.global.response.ResponseTemplate;
 import org.springframework.http.ResponseEntity;
 
@@ -8,4 +9,6 @@ import java.util.List;
 
 public interface MenteeApi {
     ResponseEntity<ResponseTemplate<List<Room>>> getRoomsById(Long id);
+
+    ResponseEntity<ResponseTemplate<MenteeProfileResponse>> getMenteeProfile(Long menteeId);
 }

--- a/src/main/java/com/cone/cone/domain/user/controller/MenteeController.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MenteeController.java
@@ -3,12 +3,10 @@ package com.cone.cone.domain.user.controller;
 import com.cone.cone.domain.room.entity.Room;
 import com.cone.cone.domain.room.service.RoomService;
 import com.cone.cone.domain.user.dto.response.*;
+import com.cone.cone.domain.user.service.*;
 import com.cone.cone.global.response.ResponseTemplate;
-import jakarta.validation.*;
-import jakarta.websocket.server.PathParam;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,12 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 import static com.cone.cone.domain.room.code.RoomSuccessCode.SUCCESS_GET_ROOMS;
+import static com.cone.cone.domain.user.code.MenteeSuccessCode.SUCCESS_GET_MENTEE_PROFILE;
 
 @RestController
 @RequestMapping("/mentees")
 @RequiredArgsConstructor
 public class MenteeController implements MenteeApi {
     private final RoomService roomService;
+    private final MenteeService menteeService;
 
     @GetMapping("/{id}/rooms")
     public ResponseEntity<ResponseTemplate<List<Room>>> getRoomsById(@PathVariable Long id) {
@@ -32,6 +32,7 @@ public class MenteeController implements MenteeApi {
 
     @GetMapping("/{menteeId}")
     public ResponseEntity<ResponseTemplate<MenteeProfileResponse>> getMenteeProfile(@PathVariable("menteeId") Long menteeId) {
-        return null;
+        val response = menteeService.getMentorProfile(menteeId);
+        return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_GET_MENTEE_PROFILE, response));
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/controller/MenteeController.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MenteeController.java
@@ -4,6 +4,7 @@ import com.cone.cone.domain.room.entity.Room;
 import com.cone.cone.domain.room.service.RoomService;
 import com.cone.cone.domain.user.dto.response.*;
 import com.cone.cone.global.response.ResponseTemplate;
+import jakarta.validation.*;
 import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -29,8 +30,8 @@ public class MenteeController implements MenteeApi {
         return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_GET_ROOMS, rooms));
     }
 
-
-    public ResponseEntity<ResponseTemplate<MenteeProfileResponse>> getMenteeProfile(Long menteeId) {
+    @GetMapping("/{menteeId}")
+    public ResponseEntity<ResponseTemplate<MenteeProfileResponse>> getMenteeProfile(@PathVariable("menteeId") Long menteeId) {
         return null;
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/controller/MenteeController.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MenteeController.java
@@ -2,6 +2,7 @@ package com.cone.cone.domain.user.controller;
 
 import com.cone.cone.domain.room.entity.Room;
 import com.cone.cone.domain.room.service.RoomService;
+import com.cone.cone.domain.user.dto.response.*;
 import com.cone.cone.global.response.ResponseTemplate;
 import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
@@ -26,5 +27,10 @@ public class MenteeController implements MenteeApi {
     public ResponseEntity<ResponseTemplate<List<Room>>> getRoomsById(@PathVariable Long id) {
         final List<Room> rooms = roomService.getRoomsByMenteeId(id);
         return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_GET_ROOMS, rooms));
+    }
+
+
+    public ResponseEntity<ResponseTemplate<MenteeProfileResponse>> getMenteeProfile(Long menteeId) {
+        return null;
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/controller/MentorController.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MentorController.java
@@ -32,7 +32,7 @@ public class MentorController implements MentorApi{
     }
 
     @GetMapping("/{mentorId}")
-    public ResponseEntity<ResponseTemplate<MentorProfileResponse>> getMentorProfile(@Valid @PathVariable("mentorId") Long mentorId) {
+    public ResponseEntity<ResponseTemplate<MentorProfileResponse>> getMentorProfile(@PathVariable("mentorId") Long mentorId) {
         val response = mentorService.getMentorProfile(mentorId);
         return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_GET_MENTOR_PROFILE, response));
     }

--- a/src/main/java/com/cone/cone/domain/user/dto/response/MenteeProfileResponse.java
+++ b/src/main/java/com/cone/cone/domain/user/dto/response/MenteeProfileResponse.java
@@ -1,0 +1,17 @@
+package com.cone.cone.domain.user.dto.response;
+
+import com.cone.cone.domain.user.entity.*;
+
+public record MenteeProfileResponse(
+        long menteeId,
+        String profileImgUrl,
+        String name,
+        String concernSummary,
+        String concernDetail,
+        String mentorPreference
+) {
+    public static MenteeProfileResponse from(Mentee mentee) {
+        return new MenteeProfileResponse(mentee.getId(), mentee.getProfileImgUrl(),
+                mentee.getUsername(), mentee.getConcernSummary(), mentee.getConcernDetail(), mentee.getMentorPreference());
+    }
+}

--- a/src/main/java/com/cone/cone/domain/user/entity/Mentee.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/Mentee.java
@@ -1,9 +1,11 @@
 package com.cone.cone.domain.user.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Table(name = "mentees")
+@Getter
 public class Mentee {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -15,4 +17,12 @@ public class Mentee {
     private String concernSummary;
     private String mentorPreference;
     private String concernDetail;
+
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    public String getProfileImgUrl() {
+        return user.getProfileImgUrl();
+    }
 }

--- a/src/main/java/com/cone/cone/domain/user/entity/Mentee.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/Mentee.java
@@ -18,6 +18,11 @@ public class Mentee {
     private String mentorPreference;
     private String concernDetail;
 
+    @Builder
+    private Mentee(User user) {
+        this.user = user;
+    }
+
     public String getUsername() {
         return user.getUsername();
     }

--- a/src/main/java/com/cone/cone/domain/user/entity/Mentor.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/Mentor.java
@@ -27,6 +27,11 @@ public class Mentor {
     private AuditStatus auditStatus;
     private String rejectReason;
 
+    @Builder
+    private Mentor(User user) {
+        this.user = user;
+    }
+
     public String getUsername() {
         return user.getUsername();
     }

--- a/src/main/java/com/cone/cone/domain/user/repository/MenteeRepository.java
+++ b/src/main/java/com/cone/cone/domain/user/repository/MenteeRepository.java
@@ -1,8 +1,13 @@
 package com.cone.cone.domain.user.repository;
 
+import static com.cone.cone.domain.user.code.MenteeExceptionCode.NOT_FOUND_MENTEE;
+
 import com.cone.cone.domain.user.entity.Mentee;
-import com.cone.cone.domain.user.entity.Mentor;
+import com.cone.cone.global.exception.*;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenteeRepository extends JpaRepository<Mentee, Long> {
+    default Mentee findByIdOrThrow(final Long menteeId) {
+        return findById(menteeId).orElseThrow(() -> new CustomException(NOT_FOUND_MENTEE));
+    }
 }

--- a/src/main/java/com/cone/cone/domain/user/service/MenteeService.java
+++ b/src/main/java/com/cone/cone/domain/user/service/MenteeService.java
@@ -1,0 +1,7 @@
+package com.cone.cone.domain.user.service;
+
+import com.cone.cone.domain.user.dto.response.*;
+
+public interface MenteeService {
+    MenteeProfileResponse getMentorProfile(Long menteeId);
+}

--- a/src/main/java/com/cone/cone/domain/user/service/MenteeServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/user/service/MenteeServiceImpl.java
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.*;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MenteeServiceImpl implements MenteeService{
-    private MenteeRepository menteeRepository;
+    private final MenteeRepository menteeRepository;
 
     public MenteeProfileResponse getMentorProfile(final Long menteeId) {
         val mentee = menteeRepository.findByIdOrThrow(menteeId);

--- a/src/main/java/com/cone/cone/domain/user/service/MenteeServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/user/service/MenteeServiceImpl.java
@@ -13,6 +13,7 @@ public class MenteeServiceImpl implements MenteeService{
     private MenteeRepository menteeRepository;
 
     public MenteeProfileResponse getMentorProfile(final Long menteeId) {
-        return null;
+        val mentee = menteeRepository.findByIdOrThrow(menteeId);
+        return MenteeProfileResponse.from(mentee);
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/service/MenteeServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/user/service/MenteeServiceImpl.java
@@ -1,0 +1,18 @@
+package com.cone.cone.domain.user.service;
+
+import com.cone.cone.domain.user.dto.response.*;
+import com.cone.cone.domain.user.repository.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MenteeServiceImpl implements MenteeService{
+    private MenteeRepository menteeRepository;
+
+    public MenteeProfileResponse getMentorProfile(final Long menteeId) {
+        return null;
+    }
+}


### PR DESCRIPTION
## 📒 작업한 내용
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 멘티 프로필 조회 API 를 구현했습니다
- 사용자가 멘티, 멘토 선택 시 해당하는 role에 맞추어 레코드를 생성하는 로직을 추가했습니다

## 💭 PR POINT
<!-- 덧붙이고 싶은 내용이 있다면! -->
- X

## 📷 스크린샷
<!-- API 요청 결과를 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 멘티 프로필 조회 | <img src = "https://github.com/user-attachments/assets/eedfe109-7c07-44f2-a068-59ed124c6587" width ="500">|

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #20
