### PR TITLE
[FEAT] 멘토 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/cone/cone/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/cone/cone/domain/auth/controller/AuthController.java
@@ -2,10 +2,12 @@ package com.cone.cone.domain.auth.controller;
 
 import static com.cone.cone.domain.auth.code.AuthSuccessCode.SUCCESS_CHANGE_ROLE;
 import static com.cone.cone.domain.auth.code.AuthSuccessCode.SUCCESS_SOCIAL_LOGIN;
+import static com.cone.cone.domain.user.entity.Role.GUEST;
 
 import com.cone.cone.domain.auth.service.*;
 import com.cone.cone.domain.user.dto.request.*;
 import com.cone.cone.domain.user.dto.response.*;
+import com.cone.cone.domain.user.entity.*;
 import com.cone.cone.global.annotation.*;
 import com.cone.cone.global.response.*;
 import jakarta.servlet.http.*;
@@ -27,6 +29,7 @@ public class AuthController implements AuthApi {
     }
 
     @SessionAuth
+    @SessionRole(roles = GUEST)
     @PatchMapping("/onboarding")
     public ResponseEntity<ResponseTemplate<RoleResponse>> onboarding(HttpServletRequest httpServletRequest,
                                                                      final @SessionId Long userId,

--- a/src/main/java/com/cone/cone/domain/auth/controller/LoginTestController.java
+++ b/src/main/java/com/cone/cone/domain/auth/controller/LoginTestController.java
@@ -1,4 +1,4 @@
-package com.cone.cone.domain.user.controller;
+package com.cone.cone.domain.auth.controller;
 
 import org.springframework.beans.factory.annotation.*;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/cone/cone/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/auth/service/AuthServiceImpl.java
@@ -1,11 +1,14 @@
 package com.cone.cone.domain.auth.service;
 
+import static com.cone.cone.domain.user.entity.Role.GUEST;
+
 import com.cone.cone.domain.user.dto.request.*;
 import com.cone.cone.domain.user.dto.response.*;
 import com.cone.cone.domain.user.entity.*;
 import com.cone.cone.domain.user.repository.*;
 import com.cone.cone.external.oauth.*;
 import com.cone.cone.external.oauth.dto.*;
+import com.cone.cone.global.exception.*;
 import jakarta.servlet.http.*;
 import java.util.*;
 import lombok.*;
@@ -31,7 +34,7 @@ public class AuthServiceImpl implements AuthService {
             return RoleResponse.of(user.getRole());
         } else {
             User newUser = User.builder()
-                    .role(Role.GUEST)
+                    .role(GUEST)
                     .platformType(request.platformType())
                     .platformId(userInfo.id())
                     .username(userInfo.nickname())
@@ -47,8 +50,9 @@ public class AuthServiceImpl implements AuthService {
         val user = userRepository.findByIdOrThrow(userId);
         val role = request.role();
 
+        Role.validateRole(role);
         user.changeRole(role);
-        switch(role) {
+        switch (role) {
             case MENTEE -> menteeRepository.save(createMentee(user));
             case MENTOR -> mentorRepository.save(createMentor(user));
         }

--- a/src/main/java/com/cone/cone/domain/user/code/MentorSuccessCode.java
+++ b/src/main/java/com/cone/cone/domain/user/code/MentorSuccessCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.*;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum MentorSuccessCode implements SuccessCode {
-    SUCCESS_GET_MENTOR_PROFILE(HttpStatus.OK, "멘토 프로필 조회에 성공했습니다");
+    SUCCESS_GET_MENTOR_PROFILE(HttpStatus.OK, "멘토 프로필 조회에 성공했습니다"),
+    SUCCESS_GET_MENTORS(HttpStatus.OK, "멘토 리스트 조회에 성공했습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/cone/cone/domain/user/controller/MentorApi.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MentorApi.java
@@ -11,4 +11,6 @@ public interface MentorApi {
     ResponseEntity<ResponseTemplate<List<Room>>> getRoomsById(Long id);
 
     ResponseEntity<ResponseTemplate<MentorProfileResponse>> getMentorProfile(Long mentorId);
+
+    ResponseEntity<ResponseTemplate<List<MentorResponse>>> getMentors();
 }

--- a/src/main/java/com/cone/cone/domain/user/controller/MentorController.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MentorController.java
@@ -8,7 +8,6 @@ import com.cone.cone.global.annotation.SessionRole;
 import com.cone.cone.domain.user.dto.response.*;
 import com.cone.cone.domain.user.service.*;
 import com.cone.cone.global.response.ResponseTemplate;
-import jakarta.validation.*;
 import lombok.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,12 +38,16 @@ public class MentorController implements MentorApi{
         return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_GET_ROOMS, rooms));
     }
 
+    @SessionAuth
+    @SessionRole(roles = {MENTOR, MENTEE})
     @GetMapping("/{mentorId}")
     public ResponseEntity<ResponseTemplate<MentorProfileResponse>> getMentorProfile(@PathVariable("mentorId") Long mentorId) {
         val response = mentorService.getMentorProfile(mentorId);
         return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_GET_MENTOR_PROFILE, response));
     }
 
+    @SessionAuth
+    @SessionRole(roles = {MENTOR, MENTEE})
     @GetMapping
     public ResponseEntity<ResponseTemplate<List<MentorResponse>>> getMentors() {
         val response = mentorService.getMentors();

--- a/src/main/java/com/cone/cone/domain/user/controller/MentorController.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MentorController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 import static com.cone.cone.domain.room.code.RoomSuccessCode.SUCCESS_GET_ROOMS;
+import static com.cone.cone.domain.user.code.MentorSuccessCode.SUCCESS_GET_MENTORS;
 import static com.cone.cone.domain.user.entity.Role.MENTEE;
 import static com.cone.cone.domain.user.entity.Role.MENTOR;
 import static com.cone.cone.domain.user.code.MentorSuccessCode.SUCCESS_GET_MENTOR_PROFILE;
@@ -46,6 +47,7 @@ public class MentorController implements MentorApi{
 
     @GetMapping
     public ResponseEntity<ResponseTemplate<List<MentorResponse>>> getMentors() {
-        return null;
+        val response = mentorService.getMentors();
+        return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_GET_MENTORS, response));
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/controller/MentorController.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MentorController.java
@@ -43,4 +43,9 @@ public class MentorController implements MentorApi{
         val response = mentorService.getMentorProfile(mentorId);
         return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_GET_MENTOR_PROFILE, response));
     }
+
+    @GetMapping
+    public ResponseEntity<ResponseTemplate<List<MentorResponse>>> getMentors() {
+        return null;
+    }
 }

--- a/src/main/java/com/cone/cone/domain/user/dto/response/MentorResponse.java
+++ b/src/main/java/com/cone/cone/domain/user/dto/response/MentorResponse.java
@@ -1,0 +1,17 @@
+package com.cone.cone.domain.user.dto.response;
+
+import com.cone.cone.domain.user.entity.*;
+import java.util.*;
+
+public record MentorResponse (
+        long mentorId,
+        AuditStatus auditStatus,
+        String profileImgUrl,
+        String name,
+        List<String> keywords
+){
+    public static MentorResponse from(Mentor mentor) {
+        return new MentorResponse(mentor.getId(), mentor.getAuditStatus(),
+                mentor.getProfileImgUrl(), mentor.getUsername(), mentor.getKeywords());
+    }
+}

--- a/src/main/java/com/cone/cone/domain/user/entity/Role.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/Role.java
@@ -1,6 +1,18 @@
 package com.cone.cone.domain.user.entity;
 
+import static com.cone.cone.global.code.CommonExceptionCode.INVALID_INPUT_VALUE;
+
+import com.cone.cone.global.exception.*;
+
 public enum Role {
-    // GUEST: 멘토, 멘티 둘 중 역할을 선택하지 않고 소셜 로그인 후 이탈한 회원입니다.
-    GUEST, MENTEE, MENTOR
+    // GUEST: 멘토, 멘티 둘 중 역할을 선택하지 않고 소셜 로그인 후 이탈한 회원이며, GUEST로 권한 변경 요청은 불가합니다
+    GUEST, MENTEE, MENTOR;
+
+    public static void validateRole(Role role) {
+        boolean isNotValidRole = !(role == MENTEE || role == MENTOR);
+
+        if(isNotValidRole) {
+            throw new CustomException(INVALID_INPUT_VALUE);
+        }
+    }
 }

--- a/src/main/java/com/cone/cone/domain/user/entity/User.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/User.java
@@ -23,8 +23,7 @@ public class User {
     private String platformId;
     private String username;
     private String profileImgUrl;
-    @Column(nullable = false)
-    private String keywords;
+    private String keywords; // 온보딩에서 입력받을 수 없어 임시로 nullable하게 설정
 
     @Builder
     private User(Role role, PlatformType platformType, String platformId, String username, String profileImgUrl) {

--- a/src/main/java/com/cone/cone/domain/user/repository/MentorRepository.java
+++ b/src/main/java/com/cone/cone/domain/user/repository/MentorRepository.java
@@ -6,12 +6,14 @@ import static com.cone.cone.global.code.CommonExceptionCode.AUTHENTICATION_REQUI
 import com.cone.cone.domain.user.entity.Mentor;
 import com.cone.cone.domain.user.entity.User;
 import com.cone.cone.global.exception.*;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
+import java.util.*;
+import org.springframework.data.jpa.repository.*;
 
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
     default Mentor findByIdOrThrow(final Long mentorId) {
         return findById(mentorId).orElseThrow(() -> new CustomException(NOT_FOUND_MENTOR));
     }
+
+    @Query("select m from Mentor m where m.auditStatus = com.cone.cone.domain.user.entity.AuditStatus.APPROVED")
+    List<Mentor> findApprovedMentors();
 }

--- a/src/main/java/com/cone/cone/domain/user/service/MentorService.java
+++ b/src/main/java/com/cone/cone/domain/user/service/MentorService.java
@@ -1,7 +1,10 @@
 package com.cone.cone.domain.user.service;
 
 import com.cone.cone.domain.user.dto.response.*;
+import java.util.*;
 
 public interface MentorService {
     MentorProfileResponse getMentorProfile(Long mentorId);
+
+    List<MentorResponse> getMentors();
 }

--- a/src/main/java/com/cone/cone/domain/user/service/MentorServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/user/service/MentorServiceImpl.java
@@ -3,6 +3,7 @@ package com.cone.cone.domain.user.service;
 import com.cone.cone.domain.user.dto.response.*;
 import com.cone.cone.domain.user.entity.*;
 import com.cone.cone.domain.user.repository.*;
+import java.util.*;
 import lombok.*;
 import org.springframework.stereotype.*;
 import org.springframework.transaction.annotation.*;
@@ -16,5 +17,9 @@ public class MentorServiceImpl implements MentorService{
     public MentorProfileResponse getMentorProfile(final Long mentorId) {
         Mentor mentor = mentorRepository.findByIdOrThrow(mentorId);
         return MentorProfileResponse.from(mentor);
+    }
+
+    public List<MentorResponse> getMentors() {
+        return null;
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/service/MentorServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/user/service/MentorServiceImpl.java
@@ -4,6 +4,7 @@ import com.cone.cone.domain.user.dto.response.*;
 import com.cone.cone.domain.user.entity.*;
 import com.cone.cone.domain.user.repository.*;
 import java.util.*;
+import java.util.stream.*;
 import lombok.*;
 import org.springframework.stereotype.*;
 import org.springframework.transaction.annotation.*;
@@ -20,6 +21,9 @@ public class MentorServiceImpl implements MentorService{
     }
 
     public List<MentorResponse> getMentors() {
-        return null;
+        List<Mentor> mentors = mentorRepository.findApprovedMentors();
+        return mentors.stream()
+                .map(MentorResponse::from)
+                .toList();
     }
 }


### PR DESCRIPTION
## 📒 작업한 내용
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 멘토 리스트 조회 API를 구현했습니다

## 💭 PR POINT
<!-- 덧붙이고 싶은 내용이 있다면! -->
- 승인된 멘토만 리스트에 조회되도록 로직을 구성했습니다!

## 📷 스크린샷
<!-- API 요청 결과를 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 멘토 리스트 조회| <img src = "https://github.com/user-attachments/assets/e9b10e57-8d06-4181-b761-4065832ea472" width ="500">|
| 거절한 멘토도 포함된 데이터 구성| <img src = "https://github.com/user-attachments/assets/feb35ca9-7e65-4a3d-bbd4-65109b95f660" width ="500">|



## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #15
