### PR TITLE
[FEAT] 멘토링 신청 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### SETTING ###
 src/main/resources/application-secret.properties
+*.sql

--- a/src/main/java/com/cone/cone/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/auth/service/AuthServiceImpl.java
@@ -31,6 +31,7 @@ public class AuthServiceImpl implements AuthService {
 
         if (existingUser.isPresent()) {
             User user = existingUser.get();
+            createSession(httpServletRequest, user);
             return RoleResponse.of(user.getRole());
         } else {
             User newUser = User.builder()
@@ -41,9 +42,13 @@ public class AuthServiceImpl implements AuthService {
                     .profileImgUrl(userInfo.profileUrl())
                     .build();
             userRepository.save(newUser);
-            sessionService.generateSession(httpServletRequest, newUser.getId(), newUser.getRole());
+            createSession(httpServletRequest, newUser);
             return new RoleResponse(newUser.getRole());
         }
+    }
+
+    private void createSession(HttpServletRequest httpServletRequest, User user) {
+        sessionService.generateSession(httpServletRequest, user.getId(), user.getRole());
     }
 
     public RoleResponse changeRole(HttpServletRequest httpServletRequest, final Long userId, RoleRequest request) {

--- a/src/main/java/com/cone/cone/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/auth/service/AuthServiceImpl.java
@@ -41,7 +41,7 @@ public class AuthServiceImpl implements AuthService {
                     .profileImgUrl(userInfo.profileUrl())
                     .build();
             userRepository.save(newUser);
-            sessionService.createSession(httpServletRequest, newUser.getId(), newUser.getRole());
+            sessionService.generateSession(httpServletRequest, newUser.getId(), newUser.getRole());
             return new RoleResponse(newUser.getRole());
         }
     }
@@ -56,7 +56,7 @@ public class AuthServiceImpl implements AuthService {
             case MENTEE -> menteeRepository.save(createMentee(user));
             case MENTOR -> mentorRepository.save(createMentor(user));
         }
-        sessionService.regenerateSession(httpServletRequest, userId, user.getRole());
+        sessionService.generateSession(httpServletRequest, userId, user.getRole());
         return RoleResponse.of(user.getRole());
     }
 

--- a/src/main/java/com/cone/cone/domain/auth/service/SessionService.java
+++ b/src/main/java/com/cone/cone/domain/auth/service/SessionService.java
@@ -1,9 +1,8 @@
 package com.cone.cone.domain.auth.service;
 
+import com.cone.cone.domain.user.entity.*;
 import jakarta.servlet.http.*;
 
 public interface SessionService {
-    HttpSession createSession(HttpServletRequest request, Long id, Object role);
-
-    void regenerateSession(HttpServletRequest request, Long id, Object role);
+    void generateSession(HttpServletRequest request, Long id, Role role);
 }

--- a/src/main/java/com/cone/cone/domain/auth/service/SessionServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/auth/service/SessionServiceImpl.java
@@ -4,28 +4,27 @@ import static com.cone.cone.global.constant.SessionConstant.ID;
 import static com.cone.cone.global.constant.SessionConstant.ROLE;
 import static com.cone.cone.global.constant.SessionConstant.SESSION_TIMEOUT;
 
+import com.cone.cone.domain.user.entity.*;
 import jakarta.servlet.http.*;
 import org.springframework.stereotype.*;
 
 @Service
-public class SessionServiceImpl implements SessionService{
+public class SessionServiceImpl implements SessionService {
     @Override
-    public HttpSession createSession(HttpServletRequest request, Long id, Object role) {
-        HttpSession newSession = request.getSession(true);
-
-        newSession.setMaxInactiveInterval(SESSION_TIMEOUT);
-        newSession.setAttribute(ID, id);
-        newSession.setAttribute(ROLE, role);
-        return newSession;
-    }
-
-    @Override
-    public void regenerateSession(HttpServletRequest request, Long id, Object role) {
+    public void generateSession(HttpServletRequest request, Long id, Role role) {
         HttpSession oldSession = request.getSession(false);
 
         if (oldSession != null) {
             oldSession.invalidate();
         }
-        HttpSession newSession = createSession(request, id, role);
+        createSession(request, id, role);
+    }
+
+    private void createSession(HttpServletRequest request, Long id, Role role) {
+        HttpSession newSession = request.getSession(true);
+
+        newSession.setMaxInactiveInterval(SESSION_TIMEOUT);
+        newSession.setAttribute(ID, id);
+        newSession.setAttribute(ROLE, role);
     }
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/code/MentoringSuccessCode.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/code/MentoringSuccessCode.java
@@ -1,0 +1,24 @@
+package com.cone.cone.domain.mentorings.code;
+
+import com.cone.cone.global.code.*;
+import lombok.*;
+import org.springframework.http.*;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum MentoringSuccessCode implements SuccessCode {
+    SUCCESS_REQUEST_MENTORING(HttpStatus.OK, "멘토링 신청에 성공했습니다");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return this.status;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringApi.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringApi.java
@@ -1,10 +1,11 @@
 package com.cone.cone.domain.mentorings.controller;
 
 import com.cone.cone.domain.mentorings.dto.request.*;
+import com.cone.cone.domain.mentorings.dto.response.*;
 import com.cone.cone.global.response.*;
 import jakarta.validation.*;
 import org.springframework.http.*;
 
 public interface MentoringApi {
-    public ResponseEntity<ResponseTemplate> requestMentoring(@Valid MentoringRequest request);
+    public ResponseEntity<ResponseTemplate<MentoringIdResponse>> requestMentoring(@Valid MentoringRequest request);
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringApi.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringApi.java
@@ -7,5 +7,5 @@ import jakarta.validation.*;
 import org.springframework.http.*;
 
 public interface MentoringApi {
-    public ResponseEntity<ResponseTemplate<MentoringIdResponse>> requestMentoring(Long menteeId, @Valid MentoringRequest request);
+    ResponseEntity<ResponseTemplate<MentoringIdResponse>> requestMentoring(Long menteeId, @Valid MentoringRequest request);
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringApi.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringApi.java
@@ -1,0 +1,10 @@
+package com.cone.cone.domain.mentorings.controller;
+
+import com.cone.cone.domain.mentorings.dto.request.*;
+import com.cone.cone.global.response.*;
+import jakarta.validation.*;
+import org.springframework.http.*;
+
+public interface MentoringApi {
+    public ResponseEntity<ResponseTemplate> requestMentoring(@Valid MentoringRequest request);
+}

--- a/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringApi.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringApi.java
@@ -7,5 +7,5 @@ import jakarta.validation.*;
 import org.springframework.http.*;
 
 public interface MentoringApi {
-    public ResponseEntity<ResponseTemplate<MentoringIdResponse>> requestMentoring(@Valid MentoringRequest request);
+    public ResponseEntity<ResponseTemplate<MentoringIdResponse>> requestMentoring(Long menteeId, @Valid MentoringRequest request);
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
@@ -2,12 +2,13 @@ package com.cone.cone.domain.mentorings.controller;
 
 import com.cone.cone.domain.mentorings.dto.request.*;
 import com.cone.cone.domain.mentorings.dto.response.*;
+import com.cone.cone.global.annotation.*;
 import com.cone.cone.global.response.*;
 import org.springframework.http.*;
 
 public class MentoringController implements MentoringApi {
     @Override
-    public ResponseEntity<ResponseTemplate<MentoringIdResponse>> requestMentoring(MentoringRequest request) {
+    public ResponseEntity<ResponseTemplate<MentoringIdResponse>> requestMentoring(@SessionId Long menteeId, MentoringRequest request) {
         return null;
     }
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
@@ -19,9 +19,10 @@ public class MentoringController implements MentoringApi {
     private final MentoringService mentoringService;
 
     @SessionAuth
-    @SessionRole(roles = MENTEE)
+    @SessionRole(roles = {MENTEE})
+    @PostMapping
     @Override
-    public ResponseEntity<ResponseTemplate<MentoringIdResponse>> requestMentoring(@SessionId Long menteeId, MentoringRequest request) {
+    public ResponseEntity<ResponseTemplate<MentoringIdResponse>> requestMentoring(@SessionId Long menteeId, @RequestBody MentoringRequest request) {
         val response = mentoringService.requestMentoring(menteeId, request);
         return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_REQUEST_MENTORING, response));
     }

--- a/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
@@ -1,0 +1,12 @@
+package com.cone.cone.domain.mentorings.controller;
+
+import com.cone.cone.domain.mentorings.dto.request.*;
+import com.cone.cone.global.response.*;
+import org.springframework.http.*;
+
+public class MentoringController implements MentoringApi {
+    @Override
+    public ResponseEntity<ResponseTemplate> requestMentoring(MentoringRequest request) {
+        return null;
+    }
+}

--- a/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
@@ -19,7 +19,7 @@ public class MentoringController implements MentoringApi {
     private final MentoringService mentoringService;
 
     @SessionAuth
-    @SessionRole(roles = {MENTEE})
+    @SessionRole(roles = MENTEE)
     @PostMapping
     @Override
     public ResponseEntity<ResponseTemplate<MentoringIdResponse>> requestMentoring(@SessionId Long menteeId, @RequestBody MentoringRequest request) {

--- a/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
@@ -1,6 +1,7 @@
 package com.cone.cone.domain.mentorings.controller;
 
 import static com.cone.cone.domain.mentorings.code.MentoringSuccessCode.SUCCESS_REQUEST_MENTORING;
+import static com.cone.cone.domain.user.entity.Role.MENTEE;
 
 import com.cone.cone.domain.mentorings.dto.request.*;
 import com.cone.cone.domain.mentorings.dto.response.*;
@@ -17,6 +18,8 @@ import org.springframework.web.bind.annotation.*;
 public class MentoringController implements MentoringApi {
     private final MentoringService mentoringService;
 
+    @SessionAuth
+    @SessionRole(roles = MENTEE)
     @Override
     public ResponseEntity<ResponseTemplate<MentoringIdResponse>> requestMentoring(@SessionId Long menteeId, MentoringRequest request) {
         val response = mentoringService.requestMentoring(menteeId, request);

--- a/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
@@ -1,12 +1,13 @@
 package com.cone.cone.domain.mentorings.controller;
 
 import com.cone.cone.domain.mentorings.dto.request.*;
+import com.cone.cone.domain.mentorings.dto.response.*;
 import com.cone.cone.global.response.*;
 import org.springframework.http.*;
 
 public class MentoringController implements MentoringApi {
     @Override
-    public ResponseEntity<ResponseTemplate> requestMentoring(MentoringRequest request) {
+    public ResponseEntity<ResponseTemplate<MentoringIdResponse>> requestMentoring(MentoringRequest request) {
         return null;
     }
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
@@ -2,13 +2,22 @@ package com.cone.cone.domain.mentorings.controller;
 
 import com.cone.cone.domain.mentorings.dto.request.*;
 import com.cone.cone.domain.mentorings.dto.response.*;
+import com.cone.cone.domain.mentorings.service.*;
 import com.cone.cone.global.annotation.*;
 import com.cone.cone.global.response.*;
+import lombok.*;
 import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
 
+@RestController
+@RequestMapping("/mentorings")
+@RequiredArgsConstructor
 public class MentoringController implements MentoringApi {
+    private final MentoringService mentoringService;
+
     @Override
     public ResponseEntity<ResponseTemplate<MentoringIdResponse>> requestMentoring(@SessionId Long menteeId, MentoringRequest request) {
+        val response = mentoringService.requestMentoring(menteeId, request);
         return null;
     }
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/controller/MentoringController.java
@@ -1,5 +1,7 @@
 package com.cone.cone.domain.mentorings.controller;
 
+import static com.cone.cone.domain.mentorings.code.MentoringSuccessCode.SUCCESS_REQUEST_MENTORING;
+
 import com.cone.cone.domain.mentorings.dto.request.*;
 import com.cone.cone.domain.mentorings.dto.response.*;
 import com.cone.cone.domain.mentorings.service.*;
@@ -18,6 +20,6 @@ public class MentoringController implements MentoringApi {
     @Override
     public ResponseEntity<ResponseTemplate<MentoringIdResponse>> requestMentoring(@SessionId Long menteeId, MentoringRequest request) {
         val response = mentoringService.requestMentoring(menteeId, request);
-        return null;
+        return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_REQUEST_MENTORING, response));
     }
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/dto/request/MentoringRequest.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/dto/request/MentoringRequest.java
@@ -1,0 +1,8 @@
+package com.cone.cone.domain.mentorings.dto.request;
+
+import jakarta.validation.constraints.*;
+
+public record MentoringRequest(
+        @NotNull Long mentorId
+) {
+}

--- a/src/main/java/com/cone/cone/domain/mentorings/dto/response/MentoringIdResponse.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/dto/response/MentoringIdResponse.java
@@ -1,0 +1,9 @@
+package com.cone.cone.domain.mentorings.dto.response;
+
+public record MentoringIdResponse(
+        long mentoringId
+) {
+    public static MentoringIdResponse of (long mentoringId) {
+        return new MentoringIdResponse(mentoringId);
+    }
+}

--- a/src/main/java/com/cone/cone/domain/mentorings/entity/Mentoring.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/entity/Mentoring.java
@@ -23,4 +23,10 @@ public class Mentoring extends BaseTime {
     private int rating;
     private String reviewText;
     private String summaryFile;
+
+    @Builder
+    private Mentoring(Room room) {
+        this.status = MentoringStatus.INPROGRESS;
+        this.room = room;
+    }
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/repository/MentoringRepository.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/repository/MentoringRepository.java
@@ -1,0 +1,7 @@
+package com.cone.cone.domain.mentorings.repository;
+
+import com.cone.cone.domain.mentorings.entity.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface MentoringRepository extends JpaRepository<Long, Mentoring> {
+}

--- a/src/main/java/com/cone/cone/domain/mentorings/repository/MentoringRepository.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/repository/MentoringRepository.java
@@ -3,5 +3,5 @@ package com.cone.cone.domain.mentorings.repository;
 import com.cone.cone.domain.mentorings.entity.*;
 import org.springframework.data.jpa.repository.*;
 
-public interface MentoringRepository extends JpaRepository<Long, Mentoring> {
+public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/service/MentoringService.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/service/MentoringService.java
@@ -4,5 +4,5 @@ import com.cone.cone.domain.mentorings.dto.request.*;
 import com.cone.cone.domain.mentorings.dto.response.*;
 
 public interface MentoringService {
-    MentoringIdResponse requestMentoring(MentoringRequest request);
+    MentoringIdResponse requestMentoring(Long menteeId, MentoringRequest request);
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/service/MentoringService.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/service/MentoringService.java
@@ -1,0 +1,8 @@
+package com.cone.cone.domain.mentorings.service;
+
+import com.cone.cone.domain.mentorings.dto.request.*;
+import com.cone.cone.domain.mentorings.dto.response.*;
+
+public interface MentoringService {
+    MentoringIdResponse requestMentoring(MentoringRequest request);
+}

--- a/src/main/java/com/cone/cone/domain/mentorings/service/MentoringServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/service/MentoringServiceImpl.java
@@ -2,10 +2,43 @@ package com.cone.cone.domain.mentorings.service;
 
 import com.cone.cone.domain.mentorings.dto.request.*;
 import com.cone.cone.domain.mentorings.dto.response.*;
+import com.cone.cone.domain.mentorings.entity.*;
+import com.cone.cone.domain.mentorings.repository.*;
+import com.cone.cone.domain.room.entity.*;
+import com.cone.cone.domain.room.repository.*;
+import com.cone.cone.domain.user.entity.*;
+import com.cone.cone.domain.user.repository.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
 
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class MentoringServiceImpl implements MentoringService {
+    private final MenteeRepository menteeRepository;
+    private final MentorRepository mentorRepository;
+    private final MentoringRepository mentoringRepository;
+    private final RoomRepository roomRepository;
+
+    @Transactional
     @Override
     public MentoringIdResponse requestMentoring(final Long menteeId, final MentoringRequest request) {
-        return null;
+        val mentee = menteeRepository.findByIdOrThrow(menteeId);
+        val mentor = mentorRepository.findByIdOrThrow(request.mentorId());
+        val room = roomRepository.findByMenteeAndMentor(mentee, mentor).orElse(
+                createNewRoom(mentee, mentor)
+        );
+        val mentoring = Mentoring.builder().room(room).build();
+
+        mentoringRepository.save(mentoring);
+        return MentoringIdResponse.of(mentoring.getId());
+    }
+
+    private Room createNewRoom(Mentee mentee, Mentor mentor) {
+        return Room.builder()
+                .mentee(mentee)
+                .mentor(mentor)
+                .build();
     }
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/service/MentoringServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/service/MentoringServiceImpl.java
@@ -29,16 +29,18 @@ public class MentoringServiceImpl implements MentoringService {
         val room = roomRepository.findByMenteeAndMentor(mentee, mentor).orElse(
                 createNewRoom(mentee, mentor)
         );
-        val mentoring = Mentoring.builder().room(room).build();
+        var mentoring = Mentoring.builder().room(room).build();
 
-        mentoringRepository.save(mentoring);
+        mentoring = mentoringRepository.save(mentoring);
         return MentoringIdResponse.of(mentoring.getId());
     }
 
     private Room createNewRoom(Mentee mentee, Mentor mentor) {
-        return Room.builder()
+        val room = Room.builder()
                 .mentee(mentee)
                 .mentor(mentor)
                 .build();
+        roomRepository.save(room);
+        return room;
     }
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/service/MentoringServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/service/MentoringServiceImpl.java
@@ -1,0 +1,11 @@
+package com.cone.cone.domain.mentorings.service;
+
+import com.cone.cone.domain.mentorings.dto.request.*;
+import com.cone.cone.domain.mentorings.dto.response.*;
+
+public class MentoringServiceImpl implements MentoringService {
+    @Override
+    public MentoringIdResponse requestMentoring(MentoringRequest request) {
+        return null;
+    }
+}

--- a/src/main/java/com/cone/cone/domain/mentorings/service/MentoringServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/service/MentoringServiceImpl.java
@@ -5,7 +5,7 @@ import com.cone.cone.domain.mentorings.dto.response.*;
 
 public class MentoringServiceImpl implements MentoringService {
     @Override
-    public MentoringIdResponse requestMentoring(MentoringRequest request) {
+    public MentoringIdResponse requestMentoring(final Long menteeId, final MentoringRequest request) {
         return null;
     }
 }

--- a/src/main/java/com/cone/cone/domain/messages/service/MessageServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/messages/service/MessageServiceImpl.java
@@ -2,15 +2,9 @@ package com.cone.cone.domain.messages.service;
 
 import com.cone.cone.domain.messages.entity.Message;
 import com.cone.cone.domain.messages.repository.MessageRepository;
-import com.cone.cone.domain.room.dto.RoomCreateRequest;
 import com.cone.cone.domain.room.entity.Room;
 import com.cone.cone.domain.room.repository.RoomRepository;
-import com.cone.cone.domain.room.service.RoomService;
-import com.cone.cone.domain.user.entity.Mentee;
-import com.cone.cone.domain.user.entity.Mentor;
-import com.cone.cone.domain.user.entity.User;
-import com.cone.cone.domain.user.repository.MenteeRepository;
-import com.cone.cone.domain.user.repository.MentorRepository;
+import com.cone.cone.domain.user.entity.*;
 import com.cone.cone.domain.user.repository.UserRepository;
 import com.cone.cone.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -18,10 +12,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-import static com.cone.cone.domain.room.code.RoomExceptionCode.ALREADY_EXIST_ROOM;
 import static com.cone.cone.domain.room.code.RoomExceptionCode.NOT_FOUND_ROOM;
-import static com.cone.cone.domain.user.code.MenteeExceptionCode.NOT_FOUND_MENTEE;
-import static com.cone.cone.domain.user.code.MentorExceptionCode.NOT_FOUND_MENTOR;
 import static com.cone.cone.domain.user.code.UserExceptionCode.NOT_FOUND_USER;
 
 @Service

--- a/src/main/java/com/cone/cone/domain/room/entity/Room.java
+++ b/src/main/java/com/cone/cone/domain/room/entity/Room.java
@@ -3,13 +3,20 @@ package com.cone.cone.domain.room.entity;
 import com.cone.cone.domain.user.entity.Mentee;
 import com.cone.cone.domain.user.entity.Mentor;
 import jakarta.persistence.*;
+import jakarta.persistence.Table;
 import lombok.*;
+import org.hibernate.annotations.*;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "rooms")
+@Table(
+        name = "rooms",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "mentor_mentee_unique", columnNames = {"mentor_id", "mentee_id"})
+        }
+)
 @Getter
 public class Room {
     @Id
@@ -24,9 +31,17 @@ public class Room {
     @JoinColumn(name = "mentee_id", nullable = false, updatable = false)
     private Mentee mentee;
 
+    @ColumnDefault("false")
+    private Boolean isStable;
+
     @Builder
     private Room(Mentor mentor, Mentee mentee) {
         this.mentor = mentor;
         this.mentee = mentee;
+    }
+
+    public boolean markAsStable() {
+        this.isStable = true;
+        return true;
     }
 }

--- a/src/main/java/com/cone/cone/domain/room/entity/Room.java
+++ b/src/main/java/com/cone/cone/domain/room/entity/Room.java
@@ -38,6 +38,7 @@ public class Room {
     private Room(Mentor mentor, Mentee mentee) {
         this.mentor = mentor;
         this.mentee = mentee;
+        this.isStable = false;
     }
 
     public boolean markAsStable() {

--- a/src/main/java/com/cone/cone/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/cone/cone/domain/room/repository/RoomRepository.java
@@ -8,9 +8,10 @@ import org.springframework.data.jpa.repository.*;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
     boolean existsByMentorAndMentee(Mentor mentor, Mentee mentee);
+
     List<Room> findAllByMentor(Mentor mentor);
+
     List<Room> findAllByMentee(Mentee mentee);
 
-    @Query("select r from Room r where r.mentee.id = :menteeId and r.mentor.id = :mentorId")
-    Optional<Room> findByMenteeIdAndMentorId(Long menteeId, Long mentorId);
+    Optional<Room> findByMenteeAndMentor(Mentee mentee, Mentor mentor);
 }

--- a/src/main/java/com/cone/cone/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/cone/cone/domain/room/repository/RoomRepository.java
@@ -3,12 +3,14 @@ package com.cone.cone.domain.room.repository;
 import com.cone.cone.domain.room.entity.Room;
 import com.cone.cone.domain.user.entity.Mentee;
 import com.cone.cone.domain.user.entity.Mentor;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
+import java.util.*;
+import org.springframework.data.jpa.repository.*;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
     boolean existsByMentorAndMentee(Mentor mentor, Mentee mentee);
     List<Room> findAllByMentor(Mentor mentor);
     List<Room> findAllByMentee(Mentee mentee);
+
+    @Query("select r from Room r where r.mentee.id = :menteeId and r.mentor.id = :mentorId")
+    Optional<Room> findByMenteeIdAndMentorId(Long menteeId, Long mentorId);
 }

--- a/src/main/java/com/cone/cone/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/room/service/RoomServiceImpl.java
@@ -14,8 +14,8 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 import static com.cone.cone.domain.room.code.RoomExceptionCode.ALREADY_EXIST_ROOM;
-import static com.cone.cone.domain.user.code.MenteeExceptionCode.NOT_FOUND_MENTEE;
-import static com.cone.cone.domain.user.code.MentorExceptionCode.NOT_FOUND_MENTOR;
+import static com.cone.cone.domain.user.code.MenteeExceptionCode.INVALID_REQUEST_FIND_MENTEE;
+import static com.cone.cone.domain.user.code.MentorExceptionCode.INVALID_REQUEST_FIND_MENTOR;
 
 @Service
 @RequiredArgsConstructor
@@ -26,10 +26,10 @@ public class RoomServiceImpl implements RoomService{
 
     public Room createRoom(final RoomCreateRequest request) {
         final Mentor mentor = mentorRepository.findById(request.mentorId())
-                .orElseThrow(() -> new CustomException(NOT_FOUND_MENTOR));
+                .orElseThrow(() -> new CustomException(INVALID_REQUEST_FIND_MENTOR));
 
         final Mentee mentee = menteeRepository.findById(request.menteeId())
-                .orElseThrow(() -> new CustomException(NOT_FOUND_MENTEE));
+                .orElseThrow(() -> new CustomException(INVALID_REQUEST_FIND_MENTEE));
 
         if (roomRepository.existsByMentorAndMentee(mentor, mentee)) {
             throw new CustomException(ALREADY_EXIST_ROOM);
@@ -45,14 +45,14 @@ public class RoomServiceImpl implements RoomService{
 
     public List<Room> getRoomsByMentorId(Long mentorId) {
         final Mentor mentor = mentorRepository.findById(mentorId)
-                .orElseThrow(() -> new CustomException(NOT_FOUND_MENTOR));
+                .orElseThrow(() -> new CustomException(INVALID_REQUEST_FIND_MENTOR));
 
         return roomRepository.findAllByMentor(mentor);
     }
 
     public List<Room> getRoomsByMenteeId(Long menteeId) {
         final Mentee mentee = menteeRepository.findById(menteeId)
-                .orElseThrow(() -> new CustomException(NOT_FOUND_MENTEE));
+                .orElseThrow(() -> new CustomException(INVALID_REQUEST_FIND_MENTEE));
 
         return roomRepository.findAllByMentee(mentee);
     }

--- a/src/main/java/com/cone/cone/domain/user/code/MenteeExceptionCode.java
+++ b/src/main/java/com/cone/cone/domain/user/code/MenteeExceptionCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum MenteeExceptionCode implements ExceptionCode {
-    NOT_FOUND_MENTEE(HttpStatus.NOT_FOUND, "요청하신 멘티를 찾을 수 없습니다");
+    INVALID_REQUEST_FIND_MENTEE(HttpStatus.BAD_REQUEST, "요청하신 멘티를 찾을 수 없습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/cone/cone/domain/user/code/MentorExceptionCode.java
+++ b/src/main/java/com/cone/cone/domain/user/code/MentorExceptionCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum MentorExceptionCode implements ExceptionCode {
-    NOT_FOUND_MENTOR(HttpStatus.NOT_FOUND, "요청하신 멘토를 찾을 수 없습니다");
+    INVALID_REQUEST_FIND_MENTOR(HttpStatus.BAD_REQUEST, "요청하신 멘토를 찾을 수 없습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/cone/cone/domain/user/entity/User.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/User.java
@@ -19,7 +19,7 @@ public class User {
     private Role role;
     @Column(nullable = false) @Enumerated(value = EnumType.STRING)
     private PlatformType platformType;
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String platformId;
     private String username;
     private String profileImgUrl;

--- a/src/main/java/com/cone/cone/domain/user/repository/MenteeRepository.java
+++ b/src/main/java/com/cone/cone/domain/user/repository/MenteeRepository.java
@@ -1,6 +1,6 @@
 package com.cone.cone.domain.user.repository;
 
-import static com.cone.cone.domain.user.code.MenteeExceptionCode.NOT_FOUND_MENTEE;
+import static com.cone.cone.domain.user.code.MenteeExceptionCode.INVALID_REQUEST_FIND_MENTEE;
 
 import com.cone.cone.domain.user.entity.Mentee;
 import com.cone.cone.global.exception.*;
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenteeRepository extends JpaRepository<Mentee, Long> {
     default Mentee findByIdOrThrow(final Long menteeId) {
-        return findById(menteeId).orElseThrow(() -> new CustomException(NOT_FOUND_MENTEE));
+        return findById(menteeId).orElseThrow(() -> new CustomException(INVALID_REQUEST_FIND_MENTEE));
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/repository/MentorRepository.java
+++ b/src/main/java/com/cone/cone/domain/user/repository/MentorRepository.java
@@ -1,17 +1,15 @@
 package com.cone.cone.domain.user.repository;
 
-import static com.cone.cone.domain.user.code.MentorExceptionCode.NOT_FOUND_MENTOR;
-import static com.cone.cone.global.code.CommonExceptionCode.AUTHENTICATION_REQUIRED;
+import static com.cone.cone.domain.user.code.MentorExceptionCode.INVALID_REQUEST_FIND_MENTOR;
 
 import com.cone.cone.domain.user.entity.Mentor;
-import com.cone.cone.domain.user.entity.User;
 import com.cone.cone.global.exception.*;
 import java.util.*;
 import org.springframework.data.jpa.repository.*;
 
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
     default Mentor findByIdOrThrow(final Long mentorId) {
-        return findById(mentorId).orElseThrow(() -> new CustomException(NOT_FOUND_MENTOR));
+        return findById(mentorId).orElseThrow(() -> new CustomException(INVALID_REQUEST_FIND_MENTOR));
     }
 
     @Query("select m from Mentor m where m.auditStatus = com.cone.cone.domain.user.entity.AuditStatus.APPROVED")


### PR DESCRIPTION
## 📒 작업한 내용
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 멘토링 신청 API 구현

## 💭 PR POINT
<!-- 덧붙이고 싶은 내용이 있다면! -->
- 이미 존재하는 유저의 경우에도 세션을 다시 생성하도록 수정했습니다

## 📷 스크린샷
<!-- API 요청 결과를 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 신청 성공 | <img src = "https://github.com/user-attachments/assets/ac73dd55-e31c-4b52-91a5-024ad4ece264" width ="500">|


## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #17
