### PR TITLE
[FEAT] 멘토로 참여한 멘토링 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/cone/cone/domain/mentorings/dto/response/MentorMentoringResponse.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/dto/response/MentorMentoringResponse.java
@@ -1,0 +1,30 @@
+package com.cone.cone.domain.mentorings.dto.response;
+
+import com.cone.cone.domain.user.entity.Mentee;
+
+import java.util.List;
+
+public record MentorMentoringResponse(
+        long id,
+        long menteeId,
+        String menteeUsername,
+        String menteeProfileImgUrl,
+        String concernSummary,
+        String concernDetail,
+        String mentorPreference,
+        List<String> keywords
+
+) {
+    public static MentorMentoringResponse of(long id, Mentee mentee) {
+        return new MentorMentoringResponse(
+                id,
+                mentee.getId(),
+                mentee.getUsername(),
+                mentee.getProfileImgUrl(),
+                mentee.getConcernSummary(),
+                mentee.getConcernDetail(),
+                mentee.getMentorPreference(),
+                mentee.getKeywords()
+        );
+    }
+}

--- a/src/main/java/com/cone/cone/domain/mentorings/entity/Mentoring.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/entity/Mentoring.java
@@ -32,7 +32,7 @@ public class Mentoring extends BaseTime {
 
     @Builder
     private Mentoring(Room room) {
-        this.status = MentoringStatus.INPROGRESS;
+        this.status = MentoringStatus.PROGRESS;
         this.room = room;
     }
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/entity/Mentoring.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/entity/Mentoring.java
@@ -13,16 +13,22 @@ import lombok.*;
 public class Mentoring extends BaseTime {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String content;
+
     @Enumerated(EnumType.STRING)
     private MentoringStatus status;
+
     private String rejectionReason;
+
     @ManyToOne(fetch = FetchType.LAZY)
     private Room room;
+
     private LocalDateTime mentoringTime;
-    private int rating = 0;
-    private String reviewText;
-    private String summaryFile;
+
+    private String originalRecordFileUrl;
+
+    private String summarizedRecordFileUrl;
+
+    private Duration recordDuration;
 
     @Builder
     private Mentoring(Room room) {

--- a/src/main/java/com/cone/cone/domain/mentorings/entity/Mentoring.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/entity/Mentoring.java
@@ -32,7 +32,7 @@ public class Mentoring extends BaseTime {
 
     @Builder
     private Mentoring(Room room) {
-        this.status = MentoringStatus.PROGRESS;
+        this.status = MentoringStatus.INREVIEW;
         this.room = room;
     }
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/entity/MentoringStatus.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/entity/MentoringStatus.java
@@ -1,5 +1,5 @@
 package com.cone.cone.domain.mentorings.entity;
 
 public enum MentoringStatus {
-   INREVIEW, APPROVED, REJECTED, INPROGRESS, DONE, SUMMERIZED
+   REVIEW, APPROVED, REJECTED, DONE, SUMMARIZED
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/entity/MentoringStatus.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/entity/MentoringStatus.java
@@ -1,5 +1,14 @@
 package com.cone.cone.domain.mentorings.entity;
 
 public enum MentoringStatus {
-   REVIEW, APPROVED, REJECTED, DONE, SUMMARIZED
+   // 멘토가 신청을 검토 중
+   INREVIEW,
+   // 멘토가 신청을 수락, 멘토링 진행 전
+   APPROVED,
+   // 멘토가 신청을 거절
+   REJECTED,
+   // 멘토링 진행 후, 요약본 전달 전
+   DONE,
+   // 요약본 전달 후
+   SUMMARIZED
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/repository/MentoringRepository.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/repository/MentoringRepository.java
@@ -12,4 +12,11 @@ public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
             "where r.mentee.id = :menteeId " +
             "order by m.createdAt desc")
     List<Mentoring> findAllByMenteeIdOrderCreatedAtDesc(@Param("menteeId") Long menteeId);
+
+    @Query("select m from Mentoring m " +
+            "join fetch m.room r " +
+            "join fetch r.mentor " +
+            "where r.mentor.id = :mentorId " +
+            "order by m.createdAt desc")
+    List<Mentoring> findAllByMentorIdOrderCreatedAtDesc(@Param("mentorId") Long menteeId);
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/service/MentoringService.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/service/MentoringService.java
@@ -7,5 +7,7 @@ import java.util.*;
 public interface MentoringService {
     MentoringIdResponse requestMentoring(Long menteeId, MentoringRequest request);
 
-    List<MenteeMentoringResponse> getMentoringsForMentee(Long menteeId);
+    List<MenteeMentoringResponse> getMentoringsByMenteeId(Long menteeId);
+
+    List<MentorMentoringResponse> getMentoringsByMentorId(Long mentorId);
 }

--- a/src/main/java/com/cone/cone/domain/mentorings/service/MentoringServiceImpl.java
+++ b/src/main/java/com/cone/cone/domain/mentorings/service/MentoringServiceImpl.java
@@ -45,11 +45,19 @@ public class MentoringServiceImpl implements MentoringService {
         return room;
     }
 
-    public List<MenteeMentoringResponse> getMentoringsForMentee(final Long menteeId) {
+    public List<MenteeMentoringResponse> getMentoringsByMenteeId(final Long menteeId) {
         val mentorings = mentoringRepository.findAllByMenteeIdOrderCreatedAtDesc(menteeId);
 
         return mentorings.stream()
                 .map(mentoring -> MenteeMentoringResponse.of(mentoring.getId(), mentoring.getRoom().getMentor()))
+                .toList();
+    }
+
+    public List<MentorMentoringResponse> getMentoringsByMentorId(final Long mentorId) {
+        val mentorings = mentoringRepository.findAllByMentorIdOrderCreatedAtDesc(mentorId);
+
+        return mentorings.stream()
+                .map(mentoring -> MentorMentoringResponse.of(mentoring.getId(), mentoring.getRoom().getMentee()))
                 .toList();
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/code/MenteeSuccessCode.java
+++ b/src/main/java/com/cone/cone/domain/user/code/MenteeSuccessCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.*;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum MenteeSuccessCode implements SuccessCode {
     SUCCESS_GET_MENTEE_PROFILE(HttpStatus.OK, "멘티 프로필 조회에 성공했습니다"),
-    SUCCESS_GET_MENTORINGS_FOR_MENTEE(HttpStatus.OK, "멘티의 멘토링 신청 현황 리스트 조회에 성공했습니다");
+    SUCCESS_GET_MENTORINGS_FOR_MENTEE(HttpStatus.OK, "멘티로 참여한 멘토링 목록 조회에 성공했습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/cone/cone/domain/user/code/MentorSuccessCode.java
+++ b/src/main/java/com/cone/cone/domain/user/code/MentorSuccessCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.*;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum MentorSuccessCode implements SuccessCode {
     SUCCESS_GET_MENTOR_PROFILE(HttpStatus.OK, "멘토 프로필 조회에 성공했습니다"),
-    SUCCESS_GET_MENTORS(HttpStatus.OK, "멘토 리스트 조회에 성공했습니다");
+    SUCCESS_GET_MENTORS(HttpStatus.OK, "멘토 리스트 조회에 성공했습니다"),
+    SUCCESS_GET_MENTORINGS_FOR_MENTOR(HttpStatus.OK, "멘토로 참여한 멘토링 목록 조회에 성공했습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/cone/cone/domain/user/controller/MenteeController.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MenteeController.java
@@ -52,7 +52,7 @@ public class MenteeController implements MenteeApi {
     @GetMapping("/me/mentorings")
     @Override
     public ResponseEntity<ResponseTemplate<List<MenteeMentoringResponse>>> getMentoringsForMentee(@SessionId Long menteeId) {
-        val response = mentoringService.getMentoringsForMentee(menteeId);
+        val response = mentoringService.getMentoringsByMenteeId(menteeId);
         return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_GET_MENTORINGS_FOR_MENTEE, response));
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/controller/MentorApi.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MentorApi.java
@@ -1,5 +1,7 @@
 package com.cone.cone.domain.user.controller;
 
+import com.cone.cone.domain.mentorings.dto.response.MenteeMentoringResponse;
+import com.cone.cone.domain.mentorings.dto.response.MentorMentoringResponse;
 import com.cone.cone.domain.room.entity.Room;
 import com.cone.cone.domain.user.dto.response.*;
 import com.cone.cone.global.response.ResponseTemplate;
@@ -14,5 +16,5 @@ public interface MentorApi {
 
     ResponseEntity<ResponseTemplate<List<MentorResponse>>> getMentors();
 
-    ResponseEntity<ResponseTemplate<List<>>>
+    ResponseEntity<ResponseTemplate<List<MentorMentoringResponse>>> getMentorings(Long id);
 }

--- a/src/main/java/com/cone/cone/domain/user/controller/MentorApi.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MentorApi.java
@@ -14,5 +14,5 @@ public interface MentorApi {
 
     ResponseEntity<ResponseTemplate<List<MentorResponse>>> getMentors();
 
-
+    ResponseEntity<ResponseTemplate<List<>>>
 }

--- a/src/main/java/com/cone/cone/domain/user/controller/MentorController.java
+++ b/src/main/java/com/cone/cone/domain/user/controller/MentorController.java
@@ -1,5 +1,7 @@
 package com.cone.cone.domain.user.controller;
 
+import com.cone.cone.domain.mentorings.dto.response.MentorMentoringResponse;
+import com.cone.cone.domain.mentorings.service.MentoringService;
 import com.cone.cone.domain.room.entity.Room;
 import com.cone.cone.domain.room.service.RoomService;
 import com.cone.cone.global.annotation.SessionAuth;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 import static com.cone.cone.domain.room.code.RoomSuccessCode.SUCCESS_GET_ROOMS;
+import static com.cone.cone.domain.user.code.MenteeSuccessCode.SUCCESS_GET_MENTORINGS_FOR_MENTEE;
 import static com.cone.cone.domain.user.code.MentorSuccessCode.SUCCESS_GET_MENTORS;
 import static com.cone.cone.domain.user.entity.Role.MENTEE;
 import static com.cone.cone.domain.user.entity.Role.MENTOR;
@@ -29,6 +32,7 @@ import static com.cone.cone.domain.user.code.MentorSuccessCode.SUCCESS_GET_MENTO
 public class MentorController implements MentorApi{
     private final RoomService roomService;
     private final MentorService mentorService;
+    private final MentoringService mentoringService;
 
     @SessionAuth
     @SessionRole(roles = MENTOR)
@@ -52,5 +56,13 @@ public class MentorController implements MentorApi{
     public ResponseEntity<ResponseTemplate<List<MentorResponse>>> getMentors() {
         val response = mentorService.getMentors();
         return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_GET_MENTORS, response));
+    }
+
+    @SessionAuth
+    @SessionRole(roles = {MENTOR})
+    @GetMapping("/me/mentorings")
+    public ResponseEntity<ResponseTemplate<List<MentorMentoringResponse>>> getMentorings(Long id) {
+        val response = mentoringService.getMentoringsByMentorId(id);
+        return ResponseEntity.ok(ResponseTemplate.success(SUCCESS_GET_MENTORINGS_FOR_MENTEE, response));
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/entity/Mentee.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/Mentee.java
@@ -2,7 +2,11 @@ package com.cone.cone.domain.user.entity;
 
 import jakarta.persistence.*;
 import java.util.*;
+import java.util.stream.Collectors;
+
 import lombok.*;
+
+import static com.cone.cone.global.constant.DomainConstant.COMMA;
 
 @Entity
 @Table(name = "mentees")
@@ -18,8 +22,12 @@ public class Mentee {
     private User user;
 
     private String concernSummary;
-    private String mentorPreference;
+
     private String concernDetail;
+
+    private String mentorPreference;
+
+    private String keywords;
 
     @Builder
     private Mentee(User user) {
@@ -35,6 +43,8 @@ public class Mentee {
     }
 
     public List<String> getKeywords() {
-        return user.getKeywords();
+        return Arrays.stream(keywords.split(COMMA))
+                .map(String::trim)  // 각 항목에서 불필요한 공백을 제거
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/entity/Mentor.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/Mentor.java
@@ -21,10 +21,10 @@ public class Mentor {
     @JoinColumn(name = "id")
     private User user;
 
-    @Column(nullable = false)
+    @Column
     private String resume;
 
-    @Column(nullable = false)
+    @Column
     private String introduction;
 
     private String keywords;

--- a/src/main/java/com/cone/cone/domain/user/entity/Mentor.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/Mentor.java
@@ -2,7 +2,11 @@ package com.cone.cone.domain.user.entity;
 
 import jakarta.persistence.*;
 import java.util.*;
+import java.util.stream.Collectors;
+
 import lombok.*;
+
+import static com.cone.cone.global.constant.DomainConstant.COMMA;
 
 @Entity
 @Table(name = "mentors")
@@ -23,8 +27,11 @@ public class Mentor {
     @Column(nullable = false)
     private String introduction;
 
+    private String keywords;
+
     @Column(nullable = false) @Enumerated(value = EnumType.STRING)
     private AuditStatus auditStatus;
+
     private String rejectReason;
 
     @Builder
@@ -42,6 +49,8 @@ public class Mentor {
     }
 
     public List<String> getKeywords() {
-        return user.getKeywords();
+        return Arrays.stream(keywords.split(COMMA))
+                .map(String::trim)  // 각 항목에서 불필요한 공백을 제거
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/cone/cone/domain/user/entity/User.java
+++ b/src/main/java/com/cone/cone/domain/user/entity/User.java
@@ -15,32 +15,30 @@ import lombok.*;
 public class User {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(nullable = false) @Enumerated(value = EnumType.STRING)
-    private Role role;
+
+    private String username;
+
+    private String profileImgUrl;
+
     @Column(nullable = false) @Enumerated(value = EnumType.STRING)
     private PlatformType platformType;
+
     @Column(nullable = false, unique = true)
     private String platformId;
-    private String username;
-    private String profileImgUrl;
-    private String keywords; // 온보딩에서 입력받을 수 없어 임시로 nullable하게 설정
+
+    @Column(nullable = false) @Enumerated(value = EnumType.STRING)
+    private Role role;
 
     @Builder
     private User(Role role, PlatformType platformType, String platformId, String username, String profileImgUrl) {
-        this.role = role;
-        this.platformType = platformType;
-        this.platformId = platformId;
         this.username = username;
         this.profileImgUrl = profileImgUrl;
+        this.platformType = platformType;
+        this.platformId = platformId;
+        this.role = role;
     }
 
     public void changeRole(final Role role) {
         this.role = role;
-    }
-
-    public List<String> getKeywords() {
-        return Arrays.stream(keywords.split(COMMA))
-                .map(String::trim)  // 각 항목에서 불필요한 공백을 제거
-                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 📒 작업한 내용
- Mentor properties nullable로 변경
- 키워드 User -> Mentor/Mentee로 이동
- Mentoring 속성 정리
- 멘토로 참여한 멘토링 목록 조회 API 구현

## 💭 PR POINT
- 

## 📷 스크린샷
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 멘토로 참여한 멘토링 목록 조회 | <img src = "https://github.com/user-attachments/assets/6b22af4f-6595-44bc-9545-2c48f5fbdf6f" width ="500">|

## 🌈 관련 이슈
- Resolved: #36 
